### PR TITLE
[Parser] clean code & support nil and bool literal values

### DIFF
--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -164,10 +164,26 @@ where
     }
 
     pub fn primary(&mut self) -> miette::Result<Expr> {
-        // TODO: Find a better way to match literal regardless of their value.
-        if let TokenKind::Number(n) = self.cursor.peek().kind {
+        let token = self.cursor.peek();
+
+        if let TokenKind::Number(n) = token.kind {
             self.cursor.advance();
             return Ok(Expr::Literal(LiteralValue::Num(n)));
+        }
+
+        if let TokenKind::True = token.kind {
+            self.cursor.advance();
+            return Ok(Expr::Literal(LiteralValue::Bool(true)));
+        }
+
+        if let TokenKind::False = token.kind {
+            self.cursor.advance();
+            return Ok(Expr::Literal(LiteralValue::Bool(false)));
+        }
+
+        if let TokenKind::Nil = token.kind {
+            self.cursor.advance();
+            return Ok(Expr::Literal(LiteralValue::Nil));
         }
 
         if self.cursor.match_any(&[TokenKind::OpenParen]).is_some() {
@@ -198,5 +214,4 @@ mod tests {
 
         assert_eq!(expr.to_string(), expected);
     }
-    // go to ipad.
 }

--- a/src/parse/token_cursor.rs
+++ b/src/parse/token_cursor.rs
@@ -24,29 +24,25 @@ where
         self.tokens.next()
     }
 
-    pub fn peek(&mut self) -> Option<Token> {
-        self.tokens.peek().cloned()
+    pub fn peek(&mut self) -> Token {
+        self.tokens.peek().unwrap_or(&Token::eof()).clone()
     }
 
     pub fn consume(&mut self, kind: &TokenKind) -> miette::Result<Option<Token>> {
-        if let Some(token) = self.peek() {
-            if *kind == token.kind {
-                return Ok(self.advance());
-            }
+        if self.peek().kind == *kind {
+            return Ok(self.advance());
         }
 
         Err(miette::miette!(
-            "expected: {:?}, found: {:?}",
+            "expected: {:?} after experession, found: {:?}",
             kind,
-            self.peek().map(|t| t.kind)
+            self.peek().kind
         ))
     }
 
     pub fn match_any(&mut self, kinds: &[TokenKind]) -> Option<Token> {
-        if let Some(token) = self.peek() {
-            if kinds.contains(&token.kind) {
-                return self.advance();
-            }
+        if kinds.contains(&self.peek().kind) {
+            return self.advance();
         }
 
         None


### PR DESCRIPTION
- remove lifetime in `Expr` by replacing string slices to `String` for simplicity. 
- add nil, bool values to primary values. 
- change `Cursor::peek()` to return `Token`instead of `Option<Token>`. Default is EOF token. 