### PR TITLE
Fix `Op::Minus`'s inversion of operands

### DIFF
--- a/src/parse/literal.rs
+++ b/src/parse/literal.rs
@@ -18,7 +18,7 @@ impl LitVal {
             (LitVal::String(first), LitVal::String(second)) => {
                 Ok(LitVal::String(first.to_owned() + second))
             }
-            (LitVal::Num(n_lhs), LitVal::Num(n_rhs)) => Ok(LitVal::Num(*n_lhs + *n_rhs)),
+            (LitVal::Num(left), LitVal::Num(right)) => Ok(LitVal::Num(*left + *right)),
             _ => Err(RuntimeError::UnsupportedBinaryOp {
                 op: Op::Plus,
                 lhs: self.clone(),
@@ -30,7 +30,7 @@ impl LitVal {
 
     pub(crate) fn minus(&self, rhs: &Self) -> miette::Result<Self> {
         match (self, rhs) {
-            (LitVal::Num(n_rhs), LitVal::Num(n_lhs)) => Ok(LitVal::Num(*n_rhs - *n_lhs)),
+            (LitVal::Num(left), LitVal::Num(right)) => Ok(LitVal::Num(*left - *right)),
             _ => Err(RuntimeError::UnsupportedBinaryOp {
                 op: Op::Minus,
                 lhs: self.clone(),

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -35,7 +35,7 @@ impl Expr {
             Expr::Binary { left, op, right } => {
                 let left_literal = left.evalute()?;
                 let right_literal = right.evalute()?;
-                op.apply(right_literal, left_literal)
+                op.apply(left_literal, right_literal)
             }
             Expr::Unary { op, expr } => op.negate(expr.evalute()?),
             Expr::Grouping(expr) => expr.evalute(),

--- a/src/parse/op.rs
+++ b/src/parse/op.rs
@@ -30,6 +30,7 @@ impl TryFrom<&TokenKind> for Op {
             TokenKind::Plus => Ok(Op::Plus),
             TokenKind::Minus => Ok(Op::Minus),
             TokenKind::Star => Ok(Op::Mul),
+            TokenKind::Slash => Ok(Op::Divide),
             TokenKind::Bang => Ok(Op::Bang),
             TokenKind::EqEq => Ok(Op::EqEq),
             TokenKind::BangEq => Ok(Op::BangEq),


### PR DESCRIPTION
This add two fixes: 
- Fix the `Op::Minus` inversion of operands. 
- Fix `Op::Divide` operator: wasn't parsed from tokens. 